### PR TITLE
Update 279-naming-layer-api.txt

### DIFF
--- a/proposals/279-naming-layer-api.txt
+++ b/proposals/279-naming-layer-api.txt
@@ -518,4 +518,4 @@ Appendix A.2: Example plugins [PLUGINEXAMPLES]
 
    f) OnioNS
 
-   g) Namecoin/Blockstart
+   g) Namecoin/Blockstack


### PR DESCRIPTION
Fix (possible) spelling error.  Did you mean "Blockstack"?