### PR TITLE
Changing blockstart to blockstack due to possible typo

### DIFF
--- a/proposals/279-naming-layer-api.txt
+++ b/proposals/279-naming-layer-api.txt
@@ -518,4 +518,4 @@ Appendix A.2: Example plugins [PLUGINEXAMPLES]
 
    f) OnioNS
 
-   g) Namecoin/Blockstart
+   g) Namecoin/Blockstack


### PR DESCRIPTION
Blockstack is well known project that implements a decentralised domain naming system – an evolution of Namecoin that is blockchain independent and currently operates on Bitcoin's blockchain. Blockstart is something unknown in the space of ddns systems so I find it legit to treat it as a typo.