### PR TITLE
Authorities expose bandwidth file used in votes

### DIFF
--- a/dir-spec.txt
+++ b/dir-spec.txt
@@ -1588,6 +1588,14 @@
    and sending it in an HTTP POST request to each other authority at the URL
      http://<hostname>/tor/post/vote
 
+   If an authority has used a Bandwidth List file to generate this vote it
+   SHOULD make it available at
+
+     http://<hostname>/tor/status-vote/next/bandwidth.z
+
+   If an authority makes this file available, its headers MUST correspond to
+   the ones in the "bandwidth-file-headers" item in the vote document.
+
    If, at the start of the voting period, minus DistSeconds, an authority
    does not have a current statement from another authority, the first
    authority downloads the other's statement.


### PR DESCRIPTION
In a similar ways as authorities expose the votes for the next
consensus.
This way it can be archived by CollectTor