### PR TITLE
dir-spec: remove Keywords in bandwidth-file-headers

### DIFF
--- a/dir-spec.txt
+++ b/dir-spec.txt
@@ -2105,24 +2105,6 @@
         If an authority is configured with a V3BandwidthsFile, but parsing
         fails, this line SHOULD appear in its vote, but without any headers.
 
-        Current Keywords:
-        "timestamp" -- the Unix Epoch time in seconds of the most recent
-        generator result.
-        "version" -- the Bandwidth List format document specification version.
-        "software" -- the name of the software that created the document.
-        "software_version" -- the version of the software that created the
-        document.
-        "file_created" -- the date and time timestamp in ISO 8601 format
-        and UTC time zone when the file was created.
-        "generator_started" -- the date and time timestamp in ISO 8601 format
-        and UTC time zone when the generator started.
-        "earliest_bandwidth" -- the date and time timestamp in ISO 8601 format
-        and UTC time zone when the first relay bandwidth was obtained.
-        "latest_bandwidth" -- the date and time timestamp in ISO 8601 format
-        and UTC time zone of the most recent generator result.
-        This time MUST be identical to the initial Timestamp line.
-        This duplicate value is included to make the format easier for people
-        to read.
         First-appeared: Tor 0.3.5.1-alpha.
 
    The authority section of a vote contains the following items, followed


### PR DESCRIPTION
Remove the header's Keywords in the bandwidth-file-headers item,
since they are described in bandwidth-file-spec.txt and we should
not need to update two specifications every time they change.