### PR TITLE
dir-spec: Make extra-info-digest reflect reality

### DIFF
--- a/dir-spec.txt
+++ b/dir-spec.txt
@@ -701,17 +701,23 @@
 
        [Versions before 0.2.0.1-alpha don't recognize this]
 
-   "extra-info-digest" SP sha1digest [SP sha256-digest] NL
+   "extra-info-digest" SP sha1-digest [SP sha256-digest] NL
 
        [At most once]
 
-       "sha1-digest" is a hex-encoded digest (using upper-case characters) of
-       the router's extra-info document, as signed in the router's extra-info
-       (that is, not including the signature).  (If this field is absent, the
-       router is not uploading a corresponding extra-info document.)
+       "sha1-digest" is a hex-encoded SHA1 digest (using upper-case characters)
+       of the router's extra-info document, as signed in the router's
+       extra-info (that is, not including the signature).  (If this field is
+       absent, the router is not uploading a corresponding extra-info
+       document.)
 
        "sha256-digest" is a base64-encoded SHA256 digest of the extra-info
-       document, computed over the same data.
+       document. Unlike the "sha1-digest", this digest is calculated over the
+       entire document, including the signature. This difference is due to
+       a long-lived bug in the tor implementation that it would be difficult
+       to roll out an incremental fix for, not a design choice. Future digest
+       algorithms specified should not include the signature in the data used
+       to compute the digest.
 
        [Versions before 0.2.7.2-alpha did not include a SHA256 digest.]
        [Versions before 0.2.0.1-alpha don't recognize this field at all.]


### PR DESCRIPTION
The extra-info-digest field of server descriptors was defined to contain
either a SHA1, or a SHA1 and a SHA256 digest. These were both meant to
be computed over the same data but due to an implementation error, the
Tor network has been computing the digests over different data for a
while. This is a lot easier to fix in the spec than in the code, and
the error does not seem to cause any harm beyond being a little
confusing (which this patch should help with).

A minor fix is also made to the SHA1 digest portion of the text. This is
a typo fix and a clarification, and does not change the semantic meaning
for that portion.