### PR TITLE
#27325: Reword address format definition in section 4.5

### DIFF
--- a/tor-spec.txt
+++ b/tor-spec.txt
@@ -852,20 +852,23 @@ see tor-design.pdf.
    If version 2 or higher is negotiated, each party sends the other a
    NETINFO cell.  The cell's payload is:
 
-         Timestamp              [4 bytes]
-         Other OR's address     [variable]
-         Number of addresses    [1 byte]
-         This OR's addresses    [variable]
+      TIME       (Timestamp)                     [4 bytes]
+      OTHERADDR  (Other OR's address)            [variable]
+         ATYPE   (Address type)                  [1 byte]
+         ALEN    (Adress length)                 [1 byte]
+         AVAL    (Address value in NBO)          [ALEN bytes]
+      NMYADDR    (Number of this OR's addresses) [1 byte]
+        NMYADDR times:
+          ATYPE   (Address type)                 [1 byte]
+          ALEN    (Adress length)                [1 byte]
+          AVAL    (Address value in NBO))        [ALEN bytes]
 
-   The address format is as follows:
-         Type [1 byte]
-           * 0x04 - IPv4
-           * 0x06 - IPv6
-         Length (size of Value field) [1 byte]
-           * 4 if Type is IPv4
-           * 16 if Type is IPv6
-         Value [Variable-width]
-           * Address value in network byte order.
+   Recognized address types (ATYPE) are:
+     [04] IPv4.
+     [06] IPv6.
+
+   ALEN MUST be 4 when ATYPE is 0x04 (IPv4) and 16 when ATYPE is 0x06
+   (IPv6).
 
    The timestamp is a big-endian unsigned integer number of seconds
    since the Unix epoch. Implementations MUST ignore unexpected bytes

--- a/tor-spec.txt
+++ b/tor-spec.txt
@@ -857,10 +857,19 @@ see tor-design.pdf.
          Number of addresses    [1 byte]
          This OR's addresses    [variable]
 
-   The address format is a type/length/value sequence as given in
-   section 6.4 below, without the final TTL.  The timestamp is a
-   big-endian unsigned integer number of seconds since the Unix epoch.
-   Implementations MUST ignore unexpected bytes at the end of the cell.
+   The address format is as follows:
+         Type [1 byte]
+           * 0x04 - IPv4
+           * 0x06 - IPv6
+         Length (size of Value field) [1 byte]
+           * 4 if Type is IPv4
+           * 16 if Type is IPv6
+         Value [Variable-width]
+           * Address value in network byte order.
+
+   The timestamp is a big-endian unsigned integer number of seconds
+   since the Unix epoch. Implementations MUST ignore unexpected bytes
+   at the end of the cell.
 
    Implementations MAY use the timestamp value to help decide if their
    clocks are skewed.  Initiators MAY use "other OR's address" to help


### PR DESCRIPTION
Let's refrain from mentioning section 6.4 in here, as the format
is not exactly the same - not all address type field values from
section 6.4 make sense in NETINFO cell and NETINFO cell does not
have a TTL value at the end of each address. It's a little confusing
to suggest that there is a reuse of wire format fragment between
RELAY_RESOLVED and NETINFO cells.