### PR TITLE
dir-spec: Update bandwidth files URL Tor URL

### DIFF
--- a/dir-spec.txt
+++ b/dir-spec.txt
@@ -2688,7 +2688,8 @@
 
    The bandwidth list format is described in bandwidth-file-spec.txt.
 
-   The standard URLs for bandwidth list files first-appeared in Tor 0.3.5.
+   The standard URLs for bandwidth list files first-appeared in
+   Tor 0.4.0.4-alpha.
 
 3.5. Downloading missing certificates from other directory authorities
 


### PR DESCRIPTION
From Tor 0.4.0.4-alpha, bandwidth files are available via HTTP,
but the Tor version in which it first appeared was wrong.
Fixes #26694.