### PR TITLE
bandwidth-file: Replace KeyWord by Key

### DIFF
--- a/bandwidth-file-spec.txt
+++ b/bandwidth-file-spec.txt
@@ -98,7 +98,7 @@
     Int
     SP (space)
     NL (newline)
-    Keyword
+    KeywordChar
     ArgumentChar
     nickname
     hexdigest (a '$', followed by 40 hexadecimal characters
@@ -112,7 +112,8 @@
 
     Line ::= ArgumentChar* NL
     RelayLine ::= KeyValue (SP KeyValue)* NL
-    KeyValue ::= Keyword "=" Value
+    KeyValue ::= Key "=" Value
+    Key ::= (KeywordChar | "_")+
     Value ::= ArgumentCharValue+
     ArgumentCharValue ::= any printing ASCII character except NL and SP.
     Terminator ::= "=====" or "===="


### PR DESCRIPTION
in the nonterminals definition, so that it match implementations
and does not fail with a grammar parser.

Closes: #30373