### PR TITLE
[Tor Trac #25568]: Disallow duplicate v2 and v3 onion service intro point descriptors

### DIFF
--- a/rend-spec-v2.txt
+++ b/rend-spec-v2.txt
@@ -568,6 +568,9 @@
    [Caching may make her partitionable, but she fetched it anonymously,
     and we can't very well *not* cache it. -RD]
 
+   When parsing the descriptor's introduction points, Alice's OP should reject
+   the descriptor if duplicate introduction points exist.
+
    If Alice's OP is running 0.2.1.10-alpha or higher, it fetches v2 hidden
    service descriptors. Versions before 0.2.2.1-alpha are fetching both v0 and
    v2 descriptors in parallel. Similar to the description in section 1.4,

--- a/rend-spec-v3.txt
+++ b/rend-spec-v3.txt
@@ -1418,6 +1418,9 @@ Table of contents:
    Other encryption and authentication key formats are allowed; clients
    should ignore ones they do not recognize.
 
+   When parsing the list of introduction points, clients should reject
+   descriptors which contain duplicate introduction point entries.
+
    Clients who manage to extract the introduction points of the hidden service
    can prroceed with the introduction protocol as specified in [INTRO-PROTOCOL].
 


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/25568).