### PR TITLE
control: Add GETINFO dir/status-vote/current/consensus-microdesc

### DIFF
--- a/control-spec.txt
+++ b/control-spec.txt
@@ -811,6 +811,7 @@
      if unknown
 
     "dir/status-vote/current/consensus" [added in Tor 0.2.1.6-alpha]
+    "dir/status-vote/current/consensus-microdesc" [added in Tor 0.4.3.1-alpha]
     "dir/status/authority"
     "dir/status/fp/<F>"
     "dir/status/fp/<F1>+<F2>+<F3>"


### PR DESCRIPTION
Ticket 31684 adds support for GETINFO
dir/status-vote/current/consensus-microdesc as of Tor 0.4.3.1-alpha.

Closes 31762.