### PR TITLE
dir-spec: descriptor differences are cosmetic if 2 hours, not 12 hours

### DIFF
--- a/dir-spec.txt
+++ b/dir-spec.txt
@@ -1458,7 +1458,7 @@
       - There are non-cosmetic differences between the old descriptor and the
         new one.
       - Enough time has passed between the descriptors' publication times.
-        (Currently, 12 hours.)
+        (Currently, 2 hours.)
 
    Differences between server descriptors are "non-cosmetic" if they would be
    sufficient to force an upload as described in section 2.1 above.


### PR DESCRIPTION
See [ticket 33573](https://trac.torproject.org/projects/tor/ticket/33573).

This value of 12 hours was change in ​commit torproject/tor@cc351578 to 2 hours.