### PR TITLE
Control-spec.txt: add several circuit purposes

### DIFF
--- a/control-spec.txt
+++ b/control-spec.txt
@@ -2134,7 +2134,9 @@
 
       Purpose = "GENERAL" / "HS_CLIENT_INTRO" / "HS_CLIENT_REND" /
                 "HS_SERVICE_INTRO" / "HS_SERVICE_REND" / "TESTING" /
-                "CONTROLLER" / "MEASURE_TIMEOUT"
+                "CONTROLLER" / "MEASURE_TIMEOUT" /
+                "HS_VANGUARDS" / "PATH_BIAS_TESTING" /
+                "CIRCUIT_PADDING"
 
       HSState = "HSCI_CONNECTING" / "HSCI_INTRO_SENT" / "HSCI_DONE" /
                 "HSCR_CONNECTING" / "HSCR_ESTABLISHED_IDLE" /
@@ -2183,6 +2185,12 @@
       TESTING         (reachability-testing circuit; carries no traffic)
       CONTROLLER      (circuit built by a controller)
       MEASURE_TIMEOUT (circuit being kept around to see how long it takes)
+      HS_VANGUARDS    (circuit created ahead of time when using
+                      HS vanguards, and later repurposed as needed)
+      PATH_BIAS_TESTING (circuit used to probe whether our circuits are
+                      being deliberately closed by an attacker)
+      CIRCUIT_PADDING (circuit that is being held open to disguise its
+                      true close time)
 
    The "HS_STATE" field is provided only for hidden-service circuits,
    and only in versions 0.2.3.11-alpha and later.  Clients MUST accept


### PR DESCRIPTION
This patch adds and documents the purposes HS_VANGAURD,
PATH_BIAS_TESTING, and CIRCUIT_PADDING.

Closes ticket 33640.