### PR TITLE
gitlab-ci: default branch is now main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,4 +49,4 @@ pages:
     paths:
     - public
   only:
-    - master
+    - main


### PR DESCRIPTION
https://torproject.gitlab.io/torspec/ no longer builds because it was limited to the _master_ branch.  This repo now only has _main_ as the default.